### PR TITLE
Setup default username and password for dev db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,8 @@ development: &default
   database: sorelle_development
   encoding: utf8
   host: localhost
+  username: sorelle
+  password: p@ssword!
   min_messages: warning
   pool: 2
   timeout: 5000


### PR DESCRIPTION
To setup a new user login role in Postgres on your development machine run the following sql:

``` sql
CREATE ROLE sorelle LOGIN
  ENCRYPTED PASSWORD 'p@ssword!'
  SUPERUSER INHERIT CREATEDB NOCREATEROLE NOREPLICATION;
```
